### PR TITLE
[iOS][tvOS] Fix iOS compile architecture to default to arm64, add tvOS

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -110,14 +110,29 @@ else ifneq (,$(findstring ios,$(platform)))
       IOSSDK := $(shell xcrun -sdk iphoneos -show-sdk-path)
    endif
 
-   CC = cc -arch armv7 -isysroot $(IOSSDK)
-   ifeq ($(platform),ios9)
-      CC += -miphoneos-version-min=8.0
-      PLATFORM_DEFINES += -miphoneos-version-min=8.0
-   else
+   CC = cc -arch arm64 -isysroot $(IOSSDK)
+   CC += -miphoneos-version-min=8.0
+   ifneq ($(platform),ios-arm64)
+      CC = cc -arch armv7 -isysroot $(IOSSDK)
       CC += -miphoneos-version-min=5.0
       PLATFORM_DEFINES += -miphoneos-version-min=5.0
+   else
+      PLATFORM_DEFINES += -miphoneos-version-min=8.0
    endif
+
+# tvOS
+else ifeq ($(platform),tvos-arm64)
+   TARGET := $(TARGET_NAME)_libretro_tvos.dylib
+   fpic := -fPIC
+   SHARED := -dynamiclib
+   ENDIANNESS_DEFINES := -DLSB_FIRST -DBYTE_ORDER=LITTLE_ENDIAN
+   PLATFORM_DEFINES := -DHAVE_ZLIB
+
+   ifeq ($(TVOSSDK),)
+      TVOSSDK := $(shell xcrun -sdk appletvos -show-sdk-path)
+   endif
+
+   CC = cc -arch arm64 -isysroot $(TVOSSDK)
 
 # Theos
 else ifeq ($(platform), theos_ios)


### PR DESCRIPTION
Default to arm64 for iOS builds - let's do this from now on. ARM64 has been around since 2013 on iOS and is the norm now.

Also add tvOS.