### PR TITLE
Fix for enchanced per-tile vertical scroll feature

### DIFF
--- a/core/vdp_render.c
+++ b/core/vdp_render.c
@@ -2167,9 +2167,9 @@ void render_bg_m5_vs_enhanced(int line)
 #endif
 
 #ifdef LSB_FIRST
-      v_line = (line + v_offset + vs[column]) & pf_row_mask;
+      v_line = (line + v_offset + vs[column_capped]) & pf_row_mask;
 #else
-      v_line = (line + v_offset + (vs[column] >> 16)) & pf_row_mask;
+      v_line = (line + v_offset + (vs[column_capped] >> 16)) & pf_row_mask;
 #endif
 
       nt = (uint32 *)&vram[ntab + (((v_line >> 3) << pf_shift) & 0x1FC0)];


### PR DESCRIPTION
The original implementation https://github.com/libretro/Genesis-Plus-GX-Wide/pull/22 included a mistake. It's fixed now.

Feature Off:
![Puggsy (USA)-230810-104119](https://github.com/libretro/Genesis-Plus-GX-Wide/assets/6061770/25bd56dd-ff75-4ff3-bc51-1d436b15d41e)

Feature On, before the fix:
![Puggsy (USA)-230810-104034](https://github.com/libretro/Genesis-Plus-GX-Wide/assets/6061770/2c1afc0c-1cf7-45bf-9d36-32daac901b9c)

Feature On, after the fix:
![Puggsy (USA)-230810-202517](https://github.com/libretro/Genesis-Plus-GX-Wide/assets/6061770/3236a0e0-ab89-4b71-8ec6-40cfa95771cb)
