### PR TITLE
Fix linebuf overflow when h40_extra_columns > 16

### DIFF
--- a/core/vdp_render.c
+++ b/core/vdp_render.c
@@ -584,8 +584,11 @@ static PIXEL_OUT_T pixel[0x100];
 static PIXEL_OUT_T pixel_lut[3][0x200];
 static PIXEL_OUT_T pixel_lut_m4[0x40];
 
-/* Background & Sprite line buffers */
-static uint8 linebuf[2][0x200];
+/* Background & Sprite line buffers
+ * Max width = 320 + (h40_extra_columns * 8) + 0x40 padding
+ * With h40_extra_columns up to 24: 320 + 192 + 64 = 576 (0x240)
+ */
+static uint8 linebuf[2][0x280];
 
 /* Sprite limit flag */
 static uint8 spr_ovr;


### PR DESCRIPTION
```
  0  libsystem_c.dylib              __chk_fail_overflow                                                                                                                                                                                                                                                     
  1  libsystem_c.dylib              __memset_chk    
  2  genesis.plus.gx.wide.libretro  render_obj_m5_ste                                                                                                                                                                                                                                                       
  3  genesis.plus.gx.wide.libretro  render_line     
  4  genesis.plus.gx.wide.libretro  vdp_reg_w
  5  genesis.plus.gx.wide.libretro  vdp_68k_ctrl_w
  6  genesis.plus.gx.wide.libretro  m68k_run
  7  genesis.plus.gx.wide.libretro  system_frame_scd
  8  genesis.plus.gx.wide.libretro  retro_run
```

Setting it to 0x280 instead of 0x200 allows for extra_columns up to 32